### PR TITLE
allow multiple anime entries in Watch List

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -14,6 +14,7 @@ import { useNavigation } from "expo-router";
 import useAniListApi from "../../hooks/useAniListApi";
 import { RootStackParamList } from "../../types/navigation";
 import { NavigationProp } from "@react-navigation/native";
+import { addToWatchlist } from "@/utils/watchlist"; // 👈 Added this import
 
 interface Anime {
   id: number;
@@ -35,9 +36,6 @@ export default function HomeScreen() {
       const popular = await fetchAnimeByQuery({ sort: ["POPULARITY_DESC"] });
       setTrendingAnime(trending);
       setPopularAnime(popular);
-
-      console.log("Trending Anime:", trending);
-      console.log("Popular Anime:", popular);
     };
 
     (async () => {
@@ -66,6 +64,11 @@ export default function HomeScreen() {
         <Text style={styles.cardText} numberOfLines={2}>
           {item.title.romaji}
         </Text>
+
+        {/* 👇 Add to Watchlist Button */}
+        <TouchableOpacity onPress={() => addToWatchlist(item)}>
+          <Text style={styles.addButton}>+ Add to Watchlist</Text>
+        </TouchableOpacity>
       </View>
     </TouchableOpacity>
   );
@@ -134,7 +137,7 @@ const styles = StyleSheet.create({
     marginBottom: 20,
   },
   horizontalList: {
-    height: 340,
+    height: 370,
   },
   cardWrapper: {
     marginRight: 10,
@@ -164,6 +167,12 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: "500",
     textAlign: "center",
+    marginTop: 10,
+  },
+  addButton: {
+    fontSize: 14,
+    color: "#007AFF",
+    marginTop: 6,
   },
   errorText: {
     color: "red",
@@ -178,3 +187,4 @@ const styles = StyleSheet.create({
     marginBottom: 20,
   },
 });
+

--- a/apps/mobile/app/(tabs)/watchlist.tsx
+++ b/apps/mobile/app/(tabs)/watchlist.tsx
@@ -1,12 +1,28 @@
+import { useEffect, useState } from "react";
 import { View, Text, ScrollView, StyleSheet, TouchableOpacity } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+import { getWatchlist, removeFromWatchlist } from "@/utils/watchlist";
 
 export default function WatchListScreen() {
-  const completedAnime = ["Dragon Ball Diama", "Naruto"]; // Replace with state/storage later
+  const [watchlist, setWatchlist] = useState<any[]>([]);
+
+  const load = async () => {
+    const list = await getWatchlist();
+    setWatchlist(list);
+  };
+
+  useEffect(() => {
+    const unsubscribe = load();
+    return () => unsubscribe;
+  }, []);
+
+  const handleRemove = async (id: number) => {
+    await removeFromWatchlist(id);
+    load();
+  };
 
   return (
     <View style={styles.container}>
-      {/* Header */}
       <View style={styles.header}>
         <Ionicons name="chevron-back" size={24} />
         <Text style={styles.headerTitle}>Watch List</Text>
@@ -17,59 +33,44 @@ export default function WatchListScreen() {
       </View>
 
       <ScrollView contentContainerStyle={styles.scroll}>
-        <Text style={styles.sectionTitle}>Completed</Text>
-        {completedAnime.map((anime, index) => (
-          <TouchableOpacity key={index} style={styles.tag}>
-            <Text style={styles.tagText}>{anime}</Text>
-          </TouchableOpacity>
-        ))}
+        {watchlist.length === 0 ? (
+          <Text style={styles.empty}>Your watch list is empty.</Text>
+        ) : (
+          watchlist.map((anime, index) => (
+            <TouchableOpacity key={index} style={styles.tag}>
+              <Text style={styles.tagText}>{anime.title.romaji}</Text>
+              <Ionicons
+                name="close"
+                size={16}
+                color="white"
+                style={{ marginLeft: 8 }}
+                onPress={() => handleRemove(anime.id)}
+              />
+            </TouchableOpacity>
+          ))
+        )}
       </ScrollView>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#fff",
-    paddingTop: 50,
-    paddingHorizontal: 20,
-  },
-  header: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    marginBottom: 20,
-  },
-  headerTitle: {
-    fontSize: 20,
-    fontWeight: "bold",
-  },
-  headerRight: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 10,
-  },
-  saveText: {
-    fontSize: 16,
-    fontWeight: "500",
-  },
-  scroll: {
-    gap: 20,
-  },
-  sectionTitle: {
-    fontSize: 16,
-    fontWeight: "600",
-  },
+  container: { flex: 1, backgroundColor: "#fff", paddingTop: 50, paddingHorizontal: 20 },
+  header: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", marginBottom: 20 },
+  headerTitle: { fontSize: 20, fontWeight: "bold" },
+  headerRight: { flexDirection: "row", alignItems: "center", gap: 10 },
+  saveText: { fontSize: 16, fontWeight: "500" },
+  scroll: { gap: 20 },
+  sectionTitle: { fontSize: 16, fontWeight: "600" },
+  empty: { fontSize: 16, color: "#888" },
   tag: {
     backgroundColor: "#000",
     borderRadius: 20,
     paddingHorizontal: 15,
     paddingVertical: 8,
     alignSelf: "flex-start",
+    flexDirection: "row",
+    alignItems: "center",
   },
-  tagText: {
-    color: "#fff",
-    fontWeight: "600",
-  },
+  tagText: { color: "#fff", fontWeight: "600" },
 });

--- a/apps/mobile/app/utils/watchlist.ts
+++ b/apps/mobile/app/utils/watchlist.ts
@@ -1,0 +1,23 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const WATCHLIST_KEY = "watchlist";
+
+export const getWatchlist = async () => {
+  const json = await AsyncStorage.getItem(WATCHLIST_KEY);
+  return json ? JSON.parse(json) : [];
+};
+
+export const addToWatchlist = async (anime: any) => {
+  const current = await getWatchlist();
+  const exists = current.some((a: any) => a.id === anime.id);
+  if (!exists) {
+    const updated = [...current, anime]; // ✅ append to list
+    await AsyncStorage.setItem(WATCHLIST_KEY, JSON.stringify(updated));
+  }
+};
+
+export const removeFromWatchlist = async (id: number) => {
+  const current = await getWatchlist();
+  const updated = current.filter((a: any) => a.id !== id);
+  await AsyncStorage.setItem(WATCHLIST_KEY, JSON.stringify(updated));
+};


### PR DESCRIPTION
Fixed addToWatchlist to properly append new anime instead of overwriting Now supports saving multiple anime entries without duplication Ensures Watch List persists across sessions via AsyncStorage